### PR TITLE
uses GM_* api for loading eruda

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1,26 +1,19 @@
 // ==UserScript==
 // @name         Eruda Console Injector
 // @namespace    https://venderbad.github.io
-// @version      0.0.2
+// @version      0.0.3
 // @description  A script to enable eruda console on any site
 // @author       Venderbad
 // @match        *://*/*
-// @grant        none
+// @grant        GM_addElement
 // @run-at       document-body
 // @license      WTFPL
 // ==/UserScript==
 
-(function() {
+(function () {
     if (!/eruda=true/.test(window.location) && localStorage.getItem('active-eruda') != 'true') return;
-    var s = document.createElement("script");
-    var src = "//cdn.jsdelivr.net/npm/eruda";
-    s.src = src;
-    s.addEventListener(
-        "load",
-        function() {
-            eruda.init();
-        },
-        false
-    );
-    document.body.appendChild(s);
+
+    GM_addElement('script', {
+        src: "https://cdn.jsdelivr.net/npm/eruda",
+    }).onload = () => eruda.init();
 })();


### PR DESCRIPTION
That should fix loading eruda.js on violentmonkey, without triggering firefox's fetching CSP. The loaded eruda might still failed to work because the eruda itself "loads a resource at eval" `Content Security Policy: The page’s settings blocked the loading of a resource at eval (“script-src”).` Not tested on other script managers.